### PR TITLE
[CMake] Set header files to PUBLIC and add the installation folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,9 @@ add_library(sipm SHARED
 )
 
 # Include files
-target_include_directories(sipm PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+target_include_directories(sipm PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
 set_target_properties(sipm PROPERTIES VERSION 1 OUTPUT_NAME sipm)


### PR DESCRIPTION
After https://github.com/EdoPro98/SimSiPM/commit/55af9ddbbb98d6a717b13b7781c2e46115dcfed6 the headers can not be included by another project using `SimSiPM` through the target `sipm::sipm` because they are set to PRIVATE. In addition, the installation folder was removed. The original version was correct, and it is what is typically used for header files that can be used by other projects.